### PR TITLE
Fix event emitter leak by setting listener on process exit only once

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -31,11 +31,11 @@ function spinner(opt) {
   }
 
   var cleanup = typeof opt.cleanup === 'boolean' ? opt.cleanup : true
-  if (cleanup && process.listeners('exit').map(function (fn) { return fn.name }).indexOf('exit') === -1) {
-    process.on('exit', exit)
+  if (cleanup && !process.listeners('exit').some(function (fn) { return fn.name === 'charSpinnerExit' })) {
+    process.on('exit', charSpinnerExit)
   }
 
-  function exit () {
+  function charSpinnerExit () {
     if (wrote) {
       str.write(CLEAR);
     }

--- a/spin.js
+++ b/spin.js
@@ -31,12 +31,14 @@ function spinner(opt) {
   }
 
   var cleanup = typeof opt.cleanup === 'boolean' ? opt.cleanup : true
-  if (cleanup) {
-    process.on('exit', function() {
-      if (wrote) {
-          str.write(CLEAR);
-      }
-    })
+  if (cleanup && process.listeners('exit').map(function (fn) { return fn.name }).indexOf('exit') === -1) {
+    process.on('exit', exit)
+  }
+
+  function exit () {
+    if (wrote) {
+      str.write(CLEAR);
+    }
   }
 
   module.exports.clear = function () {


### PR DESCRIPTION
Avoid warning `(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit` when using the spinners multiple times.

Got this issue while implementing a `log tail` feature for our cli that polls service logs at interval, showing the spinner between polls. 

Using simply `process.listeners('exit').indexOf(exit) === -1` didn't work as it couldn't find the `exit` function in the listeners, I guess because it is created each time.