### PR TITLE
Fix event emitter leak by setting listener on process exit only once

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -31,12 +31,14 @@ function spinner(opt) {
   }
 
   var cleanup = typeof opt.cleanup === 'boolean' ? opt.cleanup : true
-  if (cleanup) {
-    process.on('exit', function() {
-      if (wrote) {
-          str.write(CLEAR);
-      }
-    })
+  if (cleanup && !process.listeners('exit').some(function (fn) { return fn.name === 'charSpinnerExit' })) {
+    process.on('exit', charSpinnerExit)
+  }
+
+  function charSpinnerExit () {
+    if (wrote) {
+      str.write(CLEAR);
+    }
   }
 
   module.exports.clear = function () {


### PR DESCRIPTION
This PR must resolve errors with eventEmitter memory leaks.

```
(node) warning: possible EventEmitter memory leak detected. 11 exit listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at process.addListener (events.js:179:15)
    at process.on.process.addListener (node.js:668:26)
    at spinner (/usr/local/lib/node_modules/gitwalk/node_modules/char-spinner/spin.js:35:13)
    at Object.getUpToDateRefs (/usr/local/lib/node_modules/gitwalk/out/lib/git.js:107:18)
```

The code was copied from two commits in another fork from atlassian (https://github.com/atlassian/char-spinner/commit/5c31a189019ac284673c88423e3f82714bd16ae2 and https://github.com/atlassian/char-spinner/commit/330819abdbf32b56e6acffb9fd095a83e82be924)
